### PR TITLE
Remove Google Analytics surveillance tooling

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,16 +39,5 @@
     </footer>
 </section>
 
-
-{% if site.google_analytics %}
-<script type="text/javascript">
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', '{{ site.google_analytics }}', 'auto');
-    ga('send', 'pageview');
-</script>
-{% endif %}
 </body>
 </html>


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this website? There are better alternatives if you _must_ keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/